### PR TITLE
Implemented Affecto.Logging.NLog library

### DIFF
--- a/Logging.NLog.Tests/LogWriterTests.cs
+++ b/Logging.NLog.Tests/LogWriterTests.cs
@@ -1,0 +1,226 @@
+﻿using System;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using nLog = NLog;
+
+namespace Affecto.Logging.NLog.Tests
+{
+    [TestClass]
+    public class LogWriterTests
+    {
+        private LogWriter _sut;
+        private ICorrelation _correlation;
+        private nLog.ILogger _logger;
+        private ILoggerRepository _repository;
+
+        private readonly object _source = new StringBuilder();
+        private const string CallerId = "TestCaller";
+        private const string CorrelationId = "TestCorrelation";
+        private static readonly Exception Exception = new Exception("Test");
+        private const string Message = "Test message, p1: {0}, p2: {1}";
+        private static readonly object[] MessageParams = { "param1", "param2" };
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _correlation = new Correlation(CorrelationId, CallerId);
+            _logger = Substitute.For<nLog.ILogger>();
+
+            _repository = Substitute.For<ILoggerRepository>();
+            _repository.GetLogger(_source.GetType()).Returns(_logger);
+
+            _sut = new LogWriter(_repository, _source);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void LoggerRepositoryCannotBeNull()
+        {
+            _sut = new LogWriter(null, null);
+        }
+
+        [TestMethod]
+        public void SourceTypeIsLogWriterItselfIfNullSourceIsPassedInConstructor()
+        {
+            _sut = new LogWriter(_repository, null);
+            _sut.WriteLog(_correlation, LogEventLevel.Information, Exception, Message, MessageParams);
+
+            _repository.Received().GetLogger(typeof(LogWriter));
+        }
+
+        [TestMethod]
+        public void SourceTypeIsUsedToGetLogger()
+        {
+            _sut.WriteLog(_correlation, LogEventLevel.Information, Exception, Message, MessageParams);
+            _repository.Received().GetLogger(typeof(StringBuilder));
+        }
+
+        [TestMethod]
+        public void VerboseLevelStateIsCheckedAfterCreatingLogger()
+        {
+            _logger.IsDebugEnabled.Returns(false);
+
+            _repository
+                .When(r => r.GetLogger(Arg.Any<Type>()))
+                .Do(callInfo => _logger.IsDebugEnabled.Returns(true));
+
+            _sut.WriteLog(_correlation, LogEventLevel.Verbose, Exception, Message, MessageParams);
+
+            _logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
+        }
+
+        [TestMethod]
+        public void VerboseEventsAreNotLoggedIfVerboseLevelIsDisabled()
+        {
+            _logger.IsDebugEnabled.Returns(false);
+            _sut.WriteLog(_correlation, LogEventLevel.Verbose, Exception, Message, MessageParams);
+
+            _logger.DidNotReceive().Log(Arg.Any<nLog.LogEventInfo>());
+        }
+
+        [TestMethod]
+        public void InformationEventsAreLoggedEvenIfVerboseLevelIsDisabled()
+        {
+            _logger.IsDebugEnabled.Returns(false);
+            _sut.WriteLog(_correlation, LogEventLevel.Information, Exception, Message, MessageParams);
+
+            _logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
+        }
+
+        [TestMethod]
+        public void WarningEventsAreLoggedEvenIfVerboseLevelIsDisabled()
+        {
+            _logger.IsDebugEnabled.Returns(false);
+            _sut.WriteLog(_correlation, LogEventLevel.Warning, Exception, Message, MessageParams);
+
+            _logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
+        }
+
+        [TestMethod]
+        public void ErrorEventsAreLoggedEvenIfVerboseLevelIsDisabled()
+        {
+            _logger.IsDebugEnabled.Returns(false);
+            _sut.WriteLog(_correlation, LogEventLevel.Error, Exception, Message, MessageParams);
+
+            _logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
+        }
+
+        [TestMethod]
+        public void CriticalEventsAreLoggedEvenIfVerboseLevelIsDisabled()
+        {
+            _logger.IsDebugEnabled.Returns(false);
+            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+
+            _logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
+        }
+
+        [TestMethod]
+        public void LoggerIsQueriedFromRepositoryOnlyOnce()
+        {
+            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+
+            _repository.Received(1).GetLogger(Arg.Any<Type>());
+        }
+
+        [TestMethod]
+        public void MessageIsFormattedCorrectly()
+        {
+            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+
+            const string expectedMessage = "Test message, p1: param1, p2: param2";
+
+            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.FormattedMessage.Equals(expectedMessage)));
+        }
+
+        [TestMethod]
+        public void NullMessageParamsArrayIsIgnored()
+        {
+            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, null);
+
+            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Message.Equals(Message)));
+        }
+
+        [TestMethod]
+        public void EmptyMessageParamsArrayIsIgnored()
+        {
+            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, new object[0]);
+
+            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Message.Equals(Message)));
+        }
+
+        [TestMethod]
+        public void CorrelationCanBeNull()
+        {
+            _sut.WriteLog(null, LogEventLevel.Critical, Exception, Message, MessageParams);
+
+            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => !e.Properties.Keys.Contains("CallerId") && !e.Properties.Keys.Contains("CorrelationId")));
+        }
+
+        [TestMethod]
+        public void CallerIdIsLogged()
+        {
+            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+
+            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Properties["CallerId"].Equals(CallerId)));
+        }
+
+        [TestMethod]
+        public void CorrelationIdIsLogged()
+        {
+            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+
+            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Properties["CorrelationId"].Equals(CorrelationId)));
+        }
+
+        [TestMethod]
+        public void ExceptionIsLogged()
+        {
+            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+
+            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Exception == Exception));
+        }
+
+        [TestMethod]
+        public void VerboseLevelIsLogged()
+        {
+            _logger.IsDebugEnabled.Returns(true);
+            _sut.WriteLog(_correlation, LogEventLevel.Verbose, Exception, Message, MessageParams);
+
+            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Debug));
+        }
+
+        [TestMethod]
+        public void InformationLevelIsLogged()
+        {
+            _sut.WriteLog(_correlation, LogEventLevel.Information, Exception, Message, MessageParams);
+
+            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Info));
+        }
+
+        [TestMethod]
+        public void WarningLevelIsLogged()
+        {
+            _sut.WriteLog(_correlation, LogEventLevel.Warning, Exception, Message, MessageParams);
+
+            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Warn));
+        }
+
+        [TestMethod]
+        public void ErrorLevelIsLogged()
+        {
+            _sut.WriteLog(_correlation, LogEventLevel.Error, Exception, Message, MessageParams);
+
+            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Error));
+        }
+
+        [TestMethod]
+        public void CriticalLevelIsLogged()
+        {
+            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+
+            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Fatal));
+        }
+    }
+}

--- a/Logging.NLog.Tests/LogWriterTests.cs
+++ b/Logging.NLog.Tests/LogWriterTests.cs
@@ -9,12 +9,12 @@ namespace Affecto.Logging.NLog.Tests
     [TestClass]
     public class LogWriterTests
     {
-        private LogWriter _sut;
-        private ICorrelation _correlation;
-        private nLog.ILogger _logger;
-        private ILoggerRepository _repository;
+        private LogWriter sut;
+        private ICorrelation correlation;
+        private nLog.ILogger logger;
+        private ILoggerRepository repository;
 
-        private readonly object _source = new StringBuilder();
+        private readonly object source = new StringBuilder();
         private const string CallerId = "TestCaller";
         private const string CorrelationId = "TestCorrelation";
         private static readonly Exception Exception = new Exception("Test");
@@ -24,203 +24,203 @@ namespace Affecto.Logging.NLog.Tests
         [TestInitialize]
         public void Setup()
         {
-            _correlation = new Correlation(CorrelationId, CallerId);
-            _logger = Substitute.For<nLog.ILogger>();
+            correlation = new Correlation(CorrelationId, CallerId);
+            logger = Substitute.For<nLog.ILogger>();
 
-            _repository = Substitute.For<ILoggerRepository>();
-            _repository.GetLogger(_source.GetType()).Returns(_logger);
+            repository = Substitute.For<ILoggerRepository>();
+            repository.GetLogger(source.GetType()).Returns(logger);
 
-            _sut = new LogWriter(_repository, _source);
+            sut = new LogWriter(repository, source);
         }
 
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void LoggerRepositoryCannotBeNull()
         {
-            _sut = new LogWriter(null, null);
+            sut = new LogWriter(null, null);
         }
 
         [TestMethod]
         public void SourceTypeIsLogWriterItselfIfNullSourceIsPassedInConstructor()
         {
-            _sut = new LogWriter(_repository, null);
-            _sut.WriteLog(_correlation, LogEventLevel.Information, Exception, Message, MessageParams);
+            sut = new LogWriter(repository, null);
+            sut.WriteLog(correlation, LogEventLevel.Information, Exception, Message, MessageParams);
 
-            _repository.Received().GetLogger(typeof(LogWriter));
+            repository.Received().GetLogger(typeof(LogWriter));
         }
 
         [TestMethod]
         public void SourceTypeIsUsedToGetLogger()
         {
-            _sut.WriteLog(_correlation, LogEventLevel.Information, Exception, Message, MessageParams);
-            _repository.Received().GetLogger(typeof(StringBuilder));
+            sut.WriteLog(correlation, LogEventLevel.Information, Exception, Message, MessageParams);
+            repository.Received().GetLogger(typeof(StringBuilder));
         }
 
         [TestMethod]
         public void VerboseLevelStateIsCheckedAfterCreatingLogger()
         {
-            _logger.IsDebugEnabled.Returns(false);
+            logger.IsDebugEnabled.Returns(false);
 
-            _repository
+            repository
                 .When(r => r.GetLogger(Arg.Any<Type>()))
-                .Do(callInfo => _logger.IsDebugEnabled.Returns(true));
+                .Do(callInfo => logger.IsDebugEnabled.Returns(true));
 
-            _sut.WriteLog(_correlation, LogEventLevel.Verbose, Exception, Message, MessageParams);
+            sut.WriteLog(correlation, LogEventLevel.Verbose, Exception, Message, MessageParams);
 
-            _logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
+            logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
         }
 
         [TestMethod]
         public void VerboseEventsAreNotLoggedIfVerboseLevelIsDisabled()
         {
-            _logger.IsDebugEnabled.Returns(false);
-            _sut.WriteLog(_correlation, LogEventLevel.Verbose, Exception, Message, MessageParams);
+            logger.IsDebugEnabled.Returns(false);
+            sut.WriteLog(correlation, LogEventLevel.Verbose, Exception, Message, MessageParams);
 
-            _logger.DidNotReceive().Log(Arg.Any<nLog.LogEventInfo>());
+            logger.DidNotReceive().Log(Arg.Any<nLog.LogEventInfo>());
         }
 
         [TestMethod]
         public void InformationEventsAreLoggedEvenIfVerboseLevelIsDisabled()
         {
-            _logger.IsDebugEnabled.Returns(false);
-            _sut.WriteLog(_correlation, LogEventLevel.Information, Exception, Message, MessageParams);
+            logger.IsDebugEnabled.Returns(false);
+            sut.WriteLog(correlation, LogEventLevel.Information, Exception, Message, MessageParams);
 
-            _logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
+            logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
         }
 
         [TestMethod]
         public void WarningEventsAreLoggedEvenIfVerboseLevelIsDisabled()
         {
-            _logger.IsDebugEnabled.Returns(false);
-            _sut.WriteLog(_correlation, LogEventLevel.Warning, Exception, Message, MessageParams);
+            logger.IsDebugEnabled.Returns(false);
+            sut.WriteLog(correlation, LogEventLevel.Warning, Exception, Message, MessageParams);
 
-            _logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
+            logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
         }
 
         [TestMethod]
         public void ErrorEventsAreLoggedEvenIfVerboseLevelIsDisabled()
         {
-            _logger.IsDebugEnabled.Returns(false);
-            _sut.WriteLog(_correlation, LogEventLevel.Error, Exception, Message, MessageParams);
+            logger.IsDebugEnabled.Returns(false);
+            sut.WriteLog(correlation, LogEventLevel.Error, Exception, Message, MessageParams);
 
-            _logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
+            logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
         }
 
         [TestMethod]
         public void CriticalEventsAreLoggedEvenIfVerboseLevelIsDisabled()
         {
-            _logger.IsDebugEnabled.Returns(false);
-            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+            logger.IsDebugEnabled.Returns(false);
+            sut.WriteLog(correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
 
-            _logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
+            logger.Received().Log(Arg.Any<nLog.LogEventInfo>());
         }
 
         [TestMethod]
         public void LoggerIsQueriedFromRepositoryOnlyOnce()
         {
-            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
-            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+            sut.WriteLog(correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+            sut.WriteLog(correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
 
-            _repository.Received(1).GetLogger(Arg.Any<Type>());
+            repository.Received(1).GetLogger(Arg.Any<Type>());
         }
 
         [TestMethod]
         public void MessageIsFormattedCorrectly()
         {
-            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+            sut.WriteLog(correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
 
             const string expectedMessage = "Test message, p1: param1, p2: param2";
 
-            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.FormattedMessage.Equals(expectedMessage)));
+            logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.FormattedMessage.Equals(expectedMessage)));
         }
 
         [TestMethod]
         public void NullMessageParamsArrayIsIgnored()
         {
-            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, null);
+            sut.WriteLog(correlation, LogEventLevel.Critical, Exception, Message, null);
 
-            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Message.Equals(Message)));
+            logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Message.Equals(Message)));
         }
 
         [TestMethod]
         public void EmptyMessageParamsArrayIsIgnored()
         {
-            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, new object[0]);
+            sut.WriteLog(correlation, LogEventLevel.Critical, Exception, Message, new object[0]);
 
-            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Message.Equals(Message)));
+            logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Message.Equals(Message)));
         }
 
         [TestMethod]
         public void CorrelationCanBeNull()
         {
-            _sut.WriteLog(null, LogEventLevel.Critical, Exception, Message, MessageParams);
+            sut.WriteLog(null, LogEventLevel.Critical, Exception, Message, MessageParams);
 
-            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => !e.Properties.Keys.Contains("CallerId") && !e.Properties.Keys.Contains("CorrelationId")));
+            logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => !e.Properties.Keys.Contains("CallerId") && !e.Properties.Keys.Contains("CorrelationId")));
         }
 
         [TestMethod]
         public void CallerIdIsLogged()
         {
-            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+            sut.WriteLog(correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
 
-            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Properties["CallerId"].Equals(CallerId)));
+            logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Properties["CallerId"].Equals(CallerId)));
         }
 
         [TestMethod]
         public void CorrelationIdIsLogged()
         {
-            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+            sut.WriteLog(correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
 
-            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Properties["CorrelationId"].Equals(CorrelationId)));
+            logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Properties["CorrelationId"].Equals(CorrelationId)));
         }
 
         [TestMethod]
         public void ExceptionIsLogged()
         {
-            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+            sut.WriteLog(correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
 
-            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Exception == Exception));
+            logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Exception == Exception));
         }
 
         [TestMethod]
         public void VerboseLevelIsLogged()
         {
-            _logger.IsDebugEnabled.Returns(true);
-            _sut.WriteLog(_correlation, LogEventLevel.Verbose, Exception, Message, MessageParams);
+            logger.IsDebugEnabled.Returns(true);
+            sut.WriteLog(correlation, LogEventLevel.Verbose, Exception, Message, MessageParams);
 
-            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Debug));
+            logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Debug));
         }
 
         [TestMethod]
         public void InformationLevelIsLogged()
         {
-            _sut.WriteLog(_correlation, LogEventLevel.Information, Exception, Message, MessageParams);
+            sut.WriteLog(correlation, LogEventLevel.Information, Exception, Message, MessageParams);
 
-            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Info));
+            logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Info));
         }
 
         [TestMethod]
         public void WarningLevelIsLogged()
         {
-            _sut.WriteLog(_correlation, LogEventLevel.Warning, Exception, Message, MessageParams);
+            sut.WriteLog(correlation, LogEventLevel.Warning, Exception, Message, MessageParams);
 
-            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Warn));
+            logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Warn));
         }
 
         [TestMethod]
         public void ErrorLevelIsLogged()
         {
-            _sut.WriteLog(_correlation, LogEventLevel.Error, Exception, Message, MessageParams);
+            sut.WriteLog(correlation, LogEventLevel.Error, Exception, Message, MessageParams);
 
-            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Error));
+            logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Error));
         }
 
         [TestMethod]
         public void CriticalLevelIsLogged()
         {
-            _sut.WriteLog(_correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
+            sut.WriteLog(correlation, LogEventLevel.Critical, Exception, Message, MessageParams);
 
-            _logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Fatal));
+            logger.Received().Log(Arg.Is<nLog.LogEventInfo>(e => e.Level == nLog.LogLevel.Fatal));
         }
     }
 }

--- a/Logging.NLog.Tests/LoggerRepositoryTests.cs
+++ b/Logging.NLog.Tests/LoggerRepositoryTests.cs
@@ -7,33 +7,33 @@ namespace Affecto.Logging.NLog.Tests
     [TestClass]
     public class LoggerRepositoryTests
     {
-        private LoggerRepository _sut;
-        private NLogWrapper _wrapper;
+        private LoggerRepository sut;
+        private NLogWrapper wrapper;
 
         [TestInitialize]
         public void Setup()
         {
-            _wrapper = Substitute.For<NLogWrapper>();
-            _sut = new LoggerRepository(_wrapper);
+            wrapper = Substitute.For<NLogWrapper>();
+            sut = new LoggerRepository(wrapper);
         }
 
         [TestMethod]
         public void ConfigurationIsDoneOnce()
         {
-            _sut.GetLogger(typeof(string));
-            _sut.GetLogger(typeof(int));
-            _sut.GetLogger(typeof(int));
+            sut.GetLogger(typeof(string));
+            sut.GetLogger(typeof(int));
+            sut.GetLogger(typeof(int));
 
-            _wrapper.Received(1).Configure();
+            wrapper.Received(1).Configure();
         }
 
         [TestMethod]
         public void LoggerInstanceIsQueriedFromWrapper()
         {
             var logger = Substitute.For<nLog.ILogger>();
-            _wrapper.GetLogger(typeof(string)).Returns(logger);
+            wrapper.GetLogger(typeof(string)).Returns(logger);
 
-            var firstLogger = _sut.GetLogger(typeof(string));
+            var firstLogger = sut.GetLogger(typeof(string));
 
             Assert.AreSame(logger, firstLogger);
         }
@@ -42,13 +42,13 @@ namespace Affecto.Logging.NLog.Tests
         public void SameLoggerInstanceIsReturnedFromMultipleCalls()
         {
             var log = Substitute.For<nLog.ILogger>();
-            _wrapper.GetLogger(typeof(string)).Returns(log);
+            wrapper.GetLogger(typeof(string)).Returns(log);
 
-            var firstLogger = _sut.GetLogger(typeof(string));
-            var secondLogger = _sut.GetLogger(typeof(string));
+            var firstLogger = sut.GetLogger(typeof(string));
+            var secondLogger = sut.GetLogger(typeof(string));
 
             Assert.AreSame(firstLogger, secondLogger);
-            _wrapper.Received(1).GetLogger(typeof(string));
+            wrapper.Received(1).GetLogger(typeof(string));
         }
     }
 }

--- a/Logging.NLog.Tests/LoggerRepositoryTests.cs
+++ b/Logging.NLog.Tests/LoggerRepositoryTests.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NSubstitute;
+using nLog = NLog;
+
+namespace Affecto.Logging.NLog.Tests
+{
+    [TestClass]
+    public class LoggerRepositoryTests
+    {
+        private LoggerRepository _sut;
+        private NLogWrapper _wrapper;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _wrapper = Substitute.For<NLogWrapper>();
+            _sut = new LoggerRepository(_wrapper);
+        }
+
+        [TestMethod]
+        public void ConfigurationIsDoneOnce()
+        {
+            _sut.GetLogger(typeof(string));
+            _sut.GetLogger(typeof(int));
+            _sut.GetLogger(typeof(int));
+
+            _wrapper.Received(1).Configure();
+        }
+
+        [TestMethod]
+        public void LoggerInstanceIsQueriedFromWrapper()
+        {
+            var logger = Substitute.For<nLog.ILogger>();
+            _wrapper.GetLogger(typeof(string)).Returns(logger);
+
+            var firstLogger = _sut.GetLogger(typeof(string));
+
+            Assert.AreSame(logger, firstLogger);
+        }
+
+        [TestMethod]
+        public void SameLoggerInstanceIsReturnedFromMultipleCalls()
+        {
+            var log = Substitute.For<nLog.ILogger>();
+            _wrapper.GetLogger(typeof(string)).Returns(log);
+
+            var firstLogger = _sut.GetLogger(typeof(string));
+            var secondLogger = _sut.GetLogger(typeof(string));
+
+            Assert.AreSame(firstLogger, secondLogger);
+            _wrapper.Received(1).GetLogger(typeof(string));
+        }
+    }
+}

--- a/Logging.NLog.Tests/Logging.NLog.Tests.csproj
+++ b/Logging.NLog.Tests/Logging.NLog.Tests.csproj
@@ -1,0 +1,108 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1B8392E0-C306-4CC1-9836-6C99290F0393}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Affecto.Logging.NLog.Tests</RootNamespace>
+    <AssemblyName>Affecto.Logging.NLog.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.3.10\lib\net40\NLog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NSubstitute, Version=1.8.1.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.8.1.0\lib\net40\NSubstitute.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core">
+      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+    </Reference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="LoggerRepositoryTests.cs" />
+    <Compile Include="LogWriterTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Logging.NLog\Logging.NLog.csproj">
+      <Project>{9a05d2a8-7a36-42af-b036-4a472d4ad8fa}</Project>
+      <Name>Logging.NLog</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Logging\Logging.csproj">
+      <Project>{825c9ebd-8b41-4cc8-84da-9b0a13e484c9}</Project>
+      <Name>Logging</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Logging.NLog.Tests/Properties/AssemblyInfo.cs
+++ b/Logging.NLog.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Logging.NLog.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Logging.NLog.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("1b8392e0-c306-4cc1-9836-6c99290f0393")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Logging.NLog.Tests/packages.config
+++ b/Logging.NLog.Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NLog" version="4.3.10" targetFramework="net40" />
+  <package id="NSubstitute" version="1.8.1.0" targetFramework="net40" />
+</packages>

--- a/Logging.NLog/ILoggerRepository.cs
+++ b/Logging.NLog/ILoggerRepository.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using nLog = NLog;
+
+namespace Affecto.Logging.NLog
+{
+    internal interface ILoggerRepository
+    {
+        nLog.ILogger GetLogger(Type type);
+    }
+}

--- a/Logging.NLog/LogWriter.cs
+++ b/Logging.NLog/LogWriter.cs
@@ -7,9 +7,9 @@ namespace Affecto.Logging.NLog
 {
     internal class LogWriter : ILogWriter
     {
-        private readonly ILoggerRepository _loggerRepository;
-        private readonly Type _sourceType;
-        private nLog.ILogger _logger;
+        private readonly ILoggerRepository loggerRepository;
+        private readonly Type sourceType;
+        private nLog.ILogger logger;
 
         public LogWriter(ILoggerRepository loggerRepository, object source)
         {
@@ -18,24 +18,24 @@ namespace Affecto.Logging.NLog
                 throw new ArgumentNullException(nameof(loggerRepository));
             }
 
-            this._loggerRepository = loggerRepository;
+            this.loggerRepository = loggerRepository;
 
-            _sourceType = source?.GetType() ?? MethodBase.GetCurrentMethod().DeclaringType;
+            sourceType = source?.GetType() ?? MethodBase.GetCurrentMethod().DeclaringType;
         }
 
         public void WriteLog(ICorrelation correlation, LogEventLevel eventLevel, Exception exception, string message, params object[] args)
         {
-            if (_logger == null)
+            if (logger == null)
             {
-                _logger = _loggerRepository.GetLogger(_sourceType);
+                logger = loggerRepository.GetLogger(sourceType);
             }
 
-            if (eventLevel == LogEventLevel.Verbose && !_logger.IsDebugEnabled)
+            if (eventLevel == LogEventLevel.Verbose && !logger.IsDebugEnabled)
             {
                 return;
             }
 
-            var logEvent = new nLog.LogEventInfo(MapEventLevel(eventLevel), _logger.Name, CultureInfo.CurrentCulture, message, args, exception);
+            var logEvent = new nLog.LogEventInfo(MapEventLevel(eventLevel), logger.Name, CultureInfo.CurrentCulture, message, args, exception);
 
             if (correlation != null)
             {
@@ -43,7 +43,7 @@ namespace Affecto.Logging.NLog
                 logEvent.Properties["CorrelationId"] = correlation.CorrelationId;
             }
 
-            _logger.Log(logEvent);
+            logger.Log(logEvent);
         }
 
         public void WriteLog(LogEventLevel eventLevel, Exception exception, string formatMessage, params object[] args)

--- a/Logging.NLog/LogWriter.cs
+++ b/Logging.NLog/LogWriter.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Globalization;
+using System.Reflection;
+using nLog = NLog;
+
+namespace Affecto.Logging.NLog
+{
+    internal class LogWriter : ILogWriter
+    {
+        private readonly ILoggerRepository _loggerRepository;
+        private readonly Type _sourceType;
+        private nLog.ILogger _logger;
+
+        public LogWriter(ILoggerRepository loggerRepository, object source)
+        {
+            if (loggerRepository == null)
+            {
+                throw new ArgumentNullException(nameof(loggerRepository));
+            }
+
+            this._loggerRepository = loggerRepository;
+
+            _sourceType = source?.GetType() ?? MethodBase.GetCurrentMethod().DeclaringType;
+        }
+
+        public void WriteLog(ICorrelation correlation, LogEventLevel eventLevel, Exception exception, string message, params object[] args)
+        {
+            if (_logger == null)
+            {
+                _logger = _loggerRepository.GetLogger(_sourceType);
+            }
+
+            if (eventLevel == LogEventLevel.Verbose && !_logger.IsDebugEnabled)
+            {
+                return;
+            }
+
+            var logEvent = new nLog.LogEventInfo(MapEventLevel(eventLevel), _logger.Name, CultureInfo.CurrentCulture, message, args, exception);
+
+            if (correlation != null)
+            {
+                logEvent.Properties["CallerId"] = correlation.CallerId;
+                logEvent.Properties["CorrelationId"] = correlation.CorrelationId;
+            }
+
+            _logger.Log(logEvent);
+        }
+
+        public void WriteLog(LogEventLevel eventLevel, Exception exception, string formatMessage, params object[] args)
+        {
+            WriteLog(null, eventLevel, exception, formatMessage, args);
+        }
+
+        private static nLog.LogLevel MapEventLevel(LogEventLevel eventLevel)
+        {
+            switch (eventLevel)
+            {
+                case LogEventLevel.Verbose:
+                    return nLog.LogLevel.Debug;
+                case LogEventLevel.Information:
+                    return nLog.LogLevel.Info;
+                case LogEventLevel.Warning:
+                    return nLog.LogLevel.Warn;
+                case LogEventLevel.Error:
+                    return nLog.LogLevel.Error;
+                case LogEventLevel.Critical:
+                    return nLog.LogLevel.Fatal;
+                default:
+                    return nLog.LogLevel.Info;
+            }
+        }
+    }
+}

--- a/Logging.NLog/LoggerRepository.cs
+++ b/Logging.NLog/LoggerRepository.cs
@@ -6,9 +6,9 @@ namespace Affecto.Logging.NLog
 {
     internal class LoggerRepository : ILoggerRepository
     {
-        private readonly NLogWrapper _wrapper;
-        private readonly object _createLock;
-        private readonly Dictionary<Type, nLog.ILogger> _createdLoggers;
+        private readonly NLogWrapper wrapper;
+        private readonly object createLock;
+        private readonly Dictionary<Type, nLog.ILogger> createdLoggers;
 
         private bool isConfigured;
 
@@ -18,32 +18,32 @@ namespace Affecto.Logging.NLog
             {
                 throw new ArgumentNullException(nameof(wrapper));
             }
-            this._wrapper = wrapper;
+            this.wrapper = wrapper;
 
-            _createLock = new object();
-            _createdLoggers = new Dictionary<Type, nLog.ILogger>();
+            createLock = new object();
+            createdLoggers = new Dictionary<Type, nLog.ILogger>();
             isConfigured = false;
         }
 
         public nLog.ILogger GetLogger(Type type)
         {
-            lock (_createLock)
+            lock (createLock)
             {
-                if (!_createdLoggers.ContainsKey(type))
+                if (!createdLoggers.ContainsKey(type))
                 {
                     if (!isConfigured)
                     {
-                        _wrapper.Configure();
+                        wrapper.Configure();
                         isConfigured = true;
                     }
 
-                    nLog.ILogger logger = _wrapper.GetLogger(type);
-                    _createdLoggers[type] = logger;
+                    nLog.ILogger logger = wrapper.GetLogger(type);
+                    createdLoggers[type] = logger;
                     return logger;
                 }
             }
 
-            return _createdLoggers[type];
+            return createdLoggers[type];
         }
     }
 }

--- a/Logging.NLog/LoggerRepository.cs
+++ b/Logging.NLog/LoggerRepository.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using nLog = NLog;
+
+namespace Affecto.Logging.NLog
+{
+    internal class LoggerRepository : ILoggerRepository
+    {
+        private readonly NLogWrapper _wrapper;
+        private readonly object _createLock;
+        private readonly Dictionary<Type, nLog.ILogger> _createdLoggers;
+
+        private bool isConfigured;
+
+        public LoggerRepository(NLogWrapper wrapper)
+        {
+            if (wrapper == null)
+            {
+                throw new ArgumentNullException(nameof(wrapper));
+            }
+            this._wrapper = wrapper;
+
+            _createLock = new object();
+            _createdLoggers = new Dictionary<Type, nLog.ILogger>();
+            isConfigured = false;
+        }
+
+        public nLog.ILogger GetLogger(Type type)
+        {
+            lock (_createLock)
+            {
+                if (!_createdLoggers.ContainsKey(type))
+                {
+                    if (!isConfigured)
+                    {
+                        _wrapper.Configure();
+                        isConfigured = true;
+                    }
+
+                    nLog.ILogger logger = _wrapper.GetLogger(type);
+                    _createdLoggers[type] = logger;
+                    return logger;
+                }
+            }
+
+            return _createdLoggers[type];
+        }
+    }
+}

--- a/Logging.NLog/Logging.NLog.csproj
+++ b/Logging.NLog/Logging.NLog.csproj
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9A05D2A8-7A36-42AF-B036-4A472D4AD8FA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Affecto.Logging.NLog</RootNamespace>
+    <AssemblyName>Affecto.Logging.NLog</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.4.3.10\lib\net40\NLog.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ILoggerRepository.cs" />
+    <Compile Include="NLogWrapper.cs" />
+    <Compile Include="LoggerRepository.cs" />
+    <Compile Include="LogWriter.cs" />
+    <Compile Include="NLogLoggerFactory.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Logging\Logging.csproj">
+      <Project>{825C9EBD-8B41-4CC8-84DA-9B0A13E484C9}</Project>
+      <Name>Logging</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Logging.NLog.nuspec" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Logging.NLog/Logging.NLog.nuspec
+++ b/Logging.NLog/Logging.NLog.nuspec
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <authors>$author$</authors>
+    <description>$description$</description>
+    <projectUrl>https://github.com/affecto/dotnet-Logging</projectUrl>
+    <tags>affecto log logging NLog</tags>
+    <releaseNotes>Implemented NLog support for Affecto.Logging library</releaseNotes>
+  </metadata>
+</package>

--- a/Logging.NLog/NLogLoggerFactory.cs
+++ b/Logging.NLog/NLogLoggerFactory.cs
@@ -1,0 +1,12 @@
+﻿namespace Affecto.Logging.NLog
+{
+    public class NLogLoggerFactory : LoggerFactory
+    {
+        private static readonly LoggerRepository RepositorySingleton = new LoggerRepository(new NLogWrapper());
+
+        protected override ILogWriter GetLogWriter(object source)
+        {
+            return new LogWriter(RepositorySingleton, source);
+        }
+    }
+}

--- a/Logging.NLog/NLogWrapper.cs
+++ b/Logging.NLog/NLogWrapper.cs
@@ -1,0 +1,18 @@
+using System;
+using nLog = NLog;
+
+namespace Affecto.Logging.NLog
+{
+    internal class NLogWrapper
+    {
+        public virtual void Configure()
+        {
+            nLog.LogManager.ReconfigExistingLoggers();
+        }
+
+        public virtual nLog.ILogger GetLogger(Type type)
+        {
+            return nLog.LogManager.GetLogger(type.FullName);
+        }
+    }
+}

--- a/Logging.NLog/Properties/AssemblyInfo.cs
+++ b/Logging.NLog/Properties/AssemblyInfo.cs
@@ -1,0 +1,15 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+[assembly: AssemblyTitle("Affecto.Logging.NLog")]
+[assembly: AssemblyDescription("Implements the logging interfaces of Affecto.Logging package using NLog.")]
+[assembly: AssemblyCompany("Affecto")]
+
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]
+
+// This version is used by NuGet:
+[assembly: AssemblyInformationalVersion("2.0.0")]
+
+[assembly: InternalsVisibleTo("Affecto.Logging.NLog.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Logging.NLog/packages.config
+++ b/Logging.NLog/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NLog" version="4.3.10" targetFramework="net40" />
+</packages>

--- a/Logging.sln
+++ b/Logging.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Logging", "Logging\Logging.csproj", "{825C9EBD-8B41-4CC8-84DA-9B0A13E484C9}"
 EndProject
@@ -18,6 +18,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "root", "root", "{FA0DB353-4
 		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Logging.NLog", "Logging.NLog\Logging.NLog.csproj", "{9A05D2A8-7A36-42AF-B036-4A472D4AD8FA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Logging.NLog.Tests", "Logging.NLog.Tests\Logging.NLog.Tests.csproj", "{1B8392E0-C306-4CC1-9836-6C99290F0393}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,6 +45,14 @@ Global
 		{63CB9D04-8BC8-4291-ACC6-AD887BE950BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{63CB9D04-8BC8-4291-ACC6-AD887BE950BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{63CB9D04-8BC8-4291-ACC6-AD887BE950BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9A05D2A8-7A36-42AF-B036-4A472D4AD8FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9A05D2A8-7A36-42AF-B036-4A472D4AD8FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9A05D2A8-7A36-42AF-B036-4A472D4AD8FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9A05D2A8-7A36-42AF-B036-4A472D4AD8FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1B8392E0-C306-4CC1-9836-6C99290F0393}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1B8392E0-C306-4CC1-9836-6C99290F0393}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1B8392E0-C306-4CC1-9836-6C99290F0393}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1B8392E0-C306-4CC1-9836-6C99290F0393}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 * **Affecto.Logging.Log4Net**
   * Implements the logging interfaces of Affecto.Logging package using Log4Net.
   * NuGet: https://www.nuget.org/packages/Affecto.Logging.Log4Net
+* **Affecto.Logging.NLog**
+  * Implements the logging interfaces of Affecto.Logging package using NLog.
+
 
 ## Build status
 


### PR DESCRIPTION
Hi. In our project we had to adopt functionality used Affecto.Logging together with Affecto.Logging.Log4Net (made by another team) to our part of code, which already used NLog for logging. Currently we use a workaround. And it could be nice to have a NuGet package similar to Affecto.Logging.Log4Net, but made for NLog.
In my fork I have implemented Affecto.Logging.NLog library in the same manner as Affecto.Logging.Log4Net.
Please, let me know it it is good enough to be merged in your repository and published as a NuGet packege.
Thanks.